### PR TITLE
Fix export on controller function

### DIFF
--- a/api/controllers/SwaggerController.js
+++ b/api/controllers/SwaggerController.js
@@ -1,4 +1,4 @@
-export async function ShowDoc(req, res) {
+module.exports = async function ShowDoc(req, res) {
   const {
     project,
   } = req.allParams();


### PR DESCRIPTION
`export async function ShowDoc(req, res) {
^^^^^^
SyntaxError: Unexpected token export`

I had unexpected token error. After the fix it worked correctly.